### PR TITLE
7.13 compatibility fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9452,13 +9452,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/ip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/ip-regex": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
@@ -21912,13 +21905,6 @@
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
       "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
       "dev": true
-    },
-    "ip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
-      "dev": true,
-      "peer": true
     },
     "ip-regex": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev-server-port": 3000
   },
   "scripts": {
-    "build": "webpack -p --mode production --https false",
+    "build": "webpack --mode production",
     "build:dev": "webpack --mode development --https false",
     "build-dev": "webpack --mode development --https false && echo . && echo . && echo . && echo Please use 'build:dev' instead of 'build-dev'.",
     "dev-server": "webpack-dev-server --mode development",

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -429,7 +429,7 @@
                         the curly braces - {ExampleRSS}</small>
                 </li>
             </ol>
-            <p class="is-internal-text">Version 3.0.1.0</p>
+            <p class="is-internal-text">Version 3.0.2.0</p>
         </div>
 
         <div id="help-section-modes" class="help-section hidden">

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -2094,7 +2094,6 @@ function getUsersSuccess(data) {
   uiSelection.projectUsers = [];
   // map through user obj and assign names
   uiSelection.projectUsers = data.map(function (item) {
-    console.log("Mapping Users?");
     return {
       id: item.UserId,
       username: item.UserName,

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -2094,10 +2094,11 @@ function getUsersSuccess(data) {
   uiSelection.projectUsers = [];
   // map through user obj and assign names
   uiSelection.projectUsers = data.map(function (item) {
+    console.log("Mapping Users?");
     return {
       id: item.UserId,
       username: item.UserName,
-      name: item.FullName,
+      name: item.FirstName + " " + item.LastName,
     };
   });
   model.projectGetRequestsMade++;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,12 +47,13 @@ module.exports = async (env, options) => {
         template: "./src/taskpane/taskpane.html",
         chunks: ["polyfill", "taskpane"]
       }),
-      new CopyWebpackPlugin([
+      new CopyWebpackPlugin(
+        { patterns: [
         {
           to: "taskpane.css",
           from: "./src/taskpane/taskpane.css"
         }
-      ]),
+      ]}),
       new HtmlWebpackPlugin({
         filename: "commands.html",
         template: "./src/commands/commands.html",


### PR DESCRIPTION
This fix addresses issues with the 7.13 API which broke this tool. This change fixes it by using the user.FirstName & user.LastName properties to derive each user's name rather than the user.FullName property, which is now null in all cases. 

I also had to update the configuration of CopyWebpackPlugin to match it's new configuration options schema & update the webpack npm script to remove out of date cli arguments (`-p` and `--https false`), since webpack now rejects cli calls that contain unexpected arguments. 

In order to test, you will have to swap out the commented out code source locations in Manifest.xml at lines 41/42, and lines 101 - 104. I did not commit changing that to dev locations, since we do not want to deploy it with dev locations. Other than that, just building & starting it should work as normal. 