### PR TITLE
[IN:9509] reduces the page size for Test Cases

### DIFF
--- a/src/taskpane/server.js
+++ b/src/taskpane/server.js
@@ -1223,7 +1223,6 @@ function templateLoader(model, fieldTypeEnums, advancedMode) {
     }
 
     return Excel.run(function (context) {
-      console.log(context);
       // store the sheet and worksheet list for use later
       sheet = context.workbook.worksheets.getActiveWorksheet();
 

--- a/src/taskpane/server.js
+++ b/src/taskpane/server.js
@@ -77,7 +77,8 @@ var API_BASE = '/services/v6_0/RestService.svc/',
   INITIAL_HIERARCHY_OUTDENT = -20,
   GET_PAGINATION_SIZE = 100,
   MAX_ROWS_PER_PAGE_MAX = 2000,
-  MAX_ROWS_PER_PAGE_REDUCED = 200, //USED FOR TCs
+  MAX_ROWS_PER_PAGE_REDUCED = 200, //Used for complex artifacts: TCs
+  MAX_ROWS_PER_PAGE_SENDING = 64000, //Higher value for sending data
   ARTIFACT_MAX_PAGES = 999,
   FIELD_MANAGEMENT_ENUMS = {
     all: 1,
@@ -2249,7 +2250,7 @@ async function sendToSpira(model, fieldTypeEnums, isUpdate) {
   } else {
     return await Excel.run({ delayForCellEdit: true }, function (context) {
       var sheet = context.workbook.worksheets.getActiveWorksheet(),
-        sheetRange = sheet.getRangeByIndexes(1, 0, MAX_ROWS_PER_PAGE_MAX, fields.length);
+        sheetRange = sheet.getRangeByIndexes(1, 0, MAX_ROWS_PER_PAGE_SENDING, fields.length);
       sheet.load("name");
       sheetRange.load("values");
 

--- a/src/taskpane/server.js
+++ b/src/taskpane/server.js
@@ -76,7 +76,8 @@ var API_BASE = '/services/v6_0/RestService.svc/',
   API_USER_BASE = '/services/v6_0/RestService.svc/users/usernames/',
   INITIAL_HIERARCHY_OUTDENT = -20,
   GET_PAGINATION_SIZE = 100,
-  MAX_ROWS_PER_PAGE = 2000,
+  MAX_ROWS_PER_PAGE_MAX = 2000,
+  MAX_ROWS_PER_PAGE_REDUCED = 200, //USED FOR TCs
   ARTIFACT_MAX_PAGES = 999,
   FIELD_MANAGEMENT_ENUMS = {
     all: 1,
@@ -1191,6 +1192,17 @@ function templateLoader(model, fieldTypeEnums, advancedMode) {
   }
 
   var response;
+
+  //Reduce the pagination size if retrieving Test Cases
+  var MAX_ROWS_PER_PAGE = 0;
+  if (model.currentArtifact.id == params.artifactEnums.testCases) {
+    MAX_ROWS_PER_PAGE = MAX_ROWS_PER_PAGE_REDUCED;
+  }
+  else {
+    MAX_ROWS_PER_PAGE = MAX_ROWS_PER_PAGE_MAX;
+
+  }
+
   // select active sheet
   if (IS_GOOGLE) {
     sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
@@ -1211,6 +1223,7 @@ function templateLoader(model, fieldTypeEnums, advancedMode) {
     }
 
     return Excel.run(function (context) {
+      console.log(context);
       // store the sheet and worksheet list for use later
       sheet = context.workbook.worksheets.getActiveWorksheet();
 
@@ -2237,7 +2250,7 @@ async function sendToSpira(model, fieldTypeEnums, isUpdate) {
   } else {
     return await Excel.run({ delayForCellEdit: true }, function (context) {
       var sheet = context.workbook.worksheets.getActiveWorksheet(),
-        sheetRange = sheet.getRangeByIndexes(1, 0, MAX_ROWS_PER_PAGE, fields.length);
+        sheetRange = sheet.getRangeByIndexes(1, 0, MAX_ROWS_PER_PAGE_MAX, fields.length);
       sheet.load("name");
       sheetRange.load("values");
 
@@ -4611,6 +4624,16 @@ function getFromSpiraGoogle(model, fieldTypeEnums, advancedMode) {
 // @param: model: full model object from client
 // @param: enum of fieldTypeEnums used
 function getFromSpiraExcel(model, fieldTypeEnums) {
+  //Reduce the pagination size if retrieving Test Cases 
+  var MAX_ROWS_PER_PAGE = 0;
+  if (model.currentArtifact.id == params.artifactEnums.testCases) {
+    MAX_ROWS_PER_PAGE = MAX_ROWS_PER_PAGE_REDUCED;
+  }
+  else {
+    MAX_ROWS_PER_PAGE = MAX_ROWS_PER_PAGE_MAX;
+
+  }
+
   return Excel.run(function (context) {
     var fields = model.fields;
     var sheet = context.workbook.worksheets.getActiveWorksheet(),
@@ -4687,6 +4710,17 @@ function resetSheet(model, currentSheet) {
     }
   }
   else {
+
+    //Reduce the pagination size if retrieving Test Cases 
+    var MAX_ROWS_PER_PAGE = 0;
+    if (model.currentArtifact.id == params.artifactEnums.testCases) {
+      MAX_ROWS_PER_PAGE = MAX_ROWS_PER_PAGE_REDUCED;
+    }
+    else {
+      MAX_ROWS_PER_PAGE = MAX_ROWS_PER_PAGE_MAX;
+
+    }
+
     Excel.run(function (ctx) {
       var fields = model.fields;
       //complete data range from old data
@@ -4716,6 +4750,17 @@ function resetSheet(model, currentSheet) {
 // @param: fieldTypeEnums - enum of fieldTypes used
 async function getDataFromSpiraExcel(model, fieldTypeEnums) {
   // 1. get from spira
+
+  //Reduce the pagination size if retrieving Test Cases 
+  var MAX_ROWS_PER_PAGE = 0;
+  if (model.currentArtifact.id == params.artifactEnums.testCases) {
+    MAX_ROWS_PER_PAGE = MAX_ROWS_PER_PAGE_REDUCED;
+  }
+  else {
+    MAX_ROWS_PER_PAGE = MAX_ROWS_PER_PAGE_MAX;
+
+  }
+
   // note we don't do this by getting the count of each artifact first, because of a bug in getting the release count
   var multiplier = (MAX_ROWS_PER_PAGE / GET_PAGINATION_SIZE) * (model.selectedPage - 1);
   var results = {};

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -216,7 +216,7 @@
             <p>Page:</p> 
         <input type="number" id="input-page" name="selectedPageNumber" value="1" min="1"></div>
         <p class="page-label pale " for="select-page" id="input-page-label">
-            Each page brings up to 2,000 records.
+            Each page brings up to 2,000 artifacts or 200 Test Cases
         </p>
         <div class="pb-md" id="pnl-template" style="display: none">
             <p>
@@ -429,7 +429,7 @@
                         the curly braces - {ExampleRSS}</small>
                 </li>
             </ol>
-            <p class="is-internal-text">Version 3.0.2.0</p>
+            <p class="is-internal-text">Version 3.1.0.0</p>
         </div>
 
         <div id="help-section-modes" class="help-section hidden">


### PR DESCRIPTION
Fixes [IN:9509] slow Test Case retrieval by reducing the page size for this artifact to 200 records. In my tests, it took around 1 minute to retrieve the page.